### PR TITLE
Display a random quote on browser refresh

### DIFF
--- a/src/components/MotivationalQuotes.jsx
+++ b/src/components/MotivationalQuotes.jsx
@@ -1,29 +1,35 @@
 import { useEffect, useState } from "react";
 import { QUOTES } from "../utils/quotes";
 
+const STORAGE_KEY = "motivational_quote_index";
+
 export default function MotivationalQuotes() {
-  const [currentIndex, setCurrentIndex] = useState(() =>
-    Math.floor(Math.random() * QUOTES.length),
-  );
-  const [fade, setFade] = useState(true);
+  const [currentIndex, setCurrentIndex] = useState(null);
+  const [fade, setFade] = useState(false);
 
   useEffect(() => {
-    const interval = setInterval(() => {
-      setFade(false);
-      setTimeout(() => {
-        setCurrentIndex((prevIndex) => {
-          let newIndex;
-          do {
-            newIndex = Math.floor(Math.random() * QUOTES.length);
-          } while (newIndex === prevIndex); // ensure no immediate repeat
-          return newIndex;
-        });
-        setFade(true);
-      }, 500);
-    }, 5000);
+    const prevIndexString = sessionStorage.getItem(STORAGE_KEY);
+    const prevIndex = prevIndexString !== null ? Number(prevIndexString) : null;
 
-    return () => clearInterval(interval);
+    let newIndex;
+    // Prevent an infinite loop when QUOTES have only one item
+    if (QUOTES.length <= 1) {
+      newIndex = 0;
+    } else {
+      do {
+        newIndex = Math.floor(Math.random() * QUOTES.length);
+      } while (prevIndex !== null && newIndex === prevIndex);
+    }
+
+    setCurrentIndex(newIndex);
+    sessionStorage.setItem(STORAGE_KEY, String(newIndex));
+
+    setFade(true);
   }, []);
+
+  if (currentIndex === null) {
+    return null;
+  }
 
   const { q, a } = QUOTES[currentIndex];
 


### PR DESCRIPTION
# Pull Request

## Story / Issue Link

Link to the related story card or issue:  
<img width="762" height="53" alt="image" src="https://github.com/user-attachments/assets/4c95c534-a421-409e-9aa8-6c2a92f07f48" />

https://miro.com/app/board/uXjVJ6oI1BA=/?moveToWidget=3458764648154278294&cot=14

## Description of Work Done

- Display a random quote on each browser refresh

## Testing Instructions

Steps to test this PR:

1. Navigate to https://deploy-preview-23--strawberry-swirl.netlify.app/
2. Go to Home page
3. See Motivational Quote
4. Reload the same page to see if the motivational quote changes 

## Gotchas / Lessons Learned

Any tricky parts or lessons learned while implementing this PR:

- The fade-in effect is not very visible at the moment, so I’d like to revisit this later together with the updates to the MotivationBuddy component.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
