### PR TITLE
Add MotivationBuddySummary on the Job Tracking page

### DIFF
--- a/src/components/JobStats.jsx
+++ b/src/components/JobStats.jsx
@@ -28,7 +28,7 @@ const Statuses = () => {
   ).length;
 
   return (
-    <div className="flex flex-col gap-6 w-1/4">
+    <div className="flex flex-col gap-6">
       {/* Statuses */}
       <div className="rounded-3xl bg-linear-to-r from-gray-50 to-white shadow-md p-8">
         <div className="font-inter text-2xl">

--- a/src/components/MotivationBuddySummary.jsx
+++ b/src/components/MotivationBuddySummary.jsx
@@ -1,0 +1,62 @@
+import PropTypes from "prop-types";
+import feather from "../assets/feather.png";
+import ember from "../assets/ember.png";
+import egg from "../assets/egg.png";
+import babyPhoenix from "../assets/baby_phoenix.png";
+import adultPhoenix from "../assets/adult_phoenix.png";
+
+function getStageIcon(applicationsCount) {
+  if (applicationsCount >= 50) return adultPhoenix;
+  if (applicationsCount >= 35) return babyPhoenix;
+  if (applicationsCount >= 20) return egg;
+  if (applicationsCount >= 10) return ember;
+  return feather;
+}
+
+function getNextStageTarget(applicationsCount) {
+  const thresholds = [10, 20, 35, 50];
+  return thresholds.find((t) => t > applicationsCount);
+}
+
+export default function MotivationBuddySummary({ applicationsCount }) {
+  const icon = getStageIcon(applicationsCount);
+  const nextStageTarget = getNextStageTarget(applicationsCount);
+
+  // Already at the final stage
+  if (nextStageTarget === undefined) {
+    return (
+      <div className="rounded-3xl bg-white shadow-md px-12 py-6 flex flex-col items-center text-center">
+        <img src={icon} alt="Motivation Buddy stage icon" className="h-12" />
+        <p className="text-deepOrange text-lg font-medium mt-2">
+          You&apos;ve rizen!
+        </p>
+        <p className="text-deepOrange text-lg font-medium mt-2 leading-[1.2]">
+          You are unstoppable!
+        </p>
+      </div>
+    );
+  }
+
+  const remaining = nextStageTarget - applicationsCount;
+  const label = remaining === 1 ? "Application" : "Applications";
+
+  return (
+    <div className="rounded-3xl bg-white shadow-md px-12 py-6 flex flex-col items-center text-center">
+      <img src={icon} alt="Motivation Buddy stage icon" className="h-12" />
+      <p className="text-deepOrange text-lg font-medium leading-[1.2] mt-2">
+        {remaining}
+        <br />
+        {label}
+      </p>
+      <p className="text-bordeaux text-base leading-[1.2] mt-3">
+        until you reach
+        <br />
+        the next stage!
+      </p>
+    </div>
+  );
+}
+
+MotivationBuddySummary.propTypes = {
+  applicationsCount: PropTypes.number.isRequired,
+};

--- a/src/components/MotivationBuddySummary.jsx
+++ b/src/components/MotivationBuddySummary.jsx
@@ -28,7 +28,7 @@ export default function MotivationBuddySummary({ applicationsCount }) {
       <div className="rounded-3xl bg-white shadow-md px-12 py-6 flex flex-col items-center text-center">
         <img src={icon} alt="Motivation Buddy stage icon" className="h-12" />
         <p className="text-deepOrange text-lg font-medium mt-2">
-          You&apos;ve rizen!
+          You&apos;ve risen!
         </p>
         <p className="text-deepOrange text-lg font-medium mt-2 leading-[1.2]">
           You are unstoppable!

--- a/src/pages/JobTracking.jsx
+++ b/src/pages/JobTracking.jsx
@@ -268,7 +268,7 @@ const JobTracking = () => {
           </div>
         )}
 
-        <div className="w-1/4 flex flex-col gap-6">
+        <div className="w-1/5 flex flex-col gap-6">
           <MotivationBuddySummary applicationsCount={jobApps.length} />
           {/* Job Statistic Component */}
           <JobStats />

--- a/src/pages/JobTracking.jsx
+++ b/src/pages/JobTracking.jsx
@@ -8,6 +8,7 @@ import ApplicationForm from "../components/ApplicationForm";
 import SavedJobForm from "../components/SavedJobForm";
 
 import { IoIosAddCircleOutline } from "react-icons/io";
+import MotivationBuddySummary from "../components/MotivationBuddySummary.jsx";
 
 const JobTracking = () => {
   const [jobApps, setJobApps] = useState([]);
@@ -141,8 +142,11 @@ const JobTracking = () => {
           </div>
         )}
 
-        {/* Job Statistic Component */}
-        <JobStats />
+        <div className="w-1/4 flex flex-col gap-6">
+          <MotivationBuddySummary applicationsCount={jobApps.length} />
+          {/* Job Statistic Component */}
+          <JobStats />
+        </div>
       </main>
     </div>
   );


### PR DESCRIPTION
# Pull Request

## Story / Issue Link

Link to the related story card or issue:  
<img width="752" height="49" alt="image" src="https://github.com/user-attachments/assets/7d36d254-fa68-4b0c-a4af-479494744a25" />
https://miro.com/app/board/uXjVJ6oI1BA=/?moveToWidget=3458764648154278294&cot=14

## Description of Work Done

Implemented MotivationBuddySummary component and place it on the Job Tracking page.

<img width="1047" height="411" alt="image" src="https://github.com/user-attachments/assets/65cf2368-6a84-4056-b3ed-e29258b7d595" />

## Testing Instructions

Steps to test this PR:

1.  Navigate to https://deploy-preview-25--strawberry-swirl.netlify.app/
2.  Go to the Job Tracking page
3.  See the MotivationBuddySummary

If you want to verify that the image and the number change based on the number of applications, please check out this branch in your local environment.
The `applicationsCount` is on line 146 in JobTracking.jsx.
You can manually change  the `jobApps.length` value to confirm that they update correctly.

## Gotchas / Lessons Learned

Any tricky parts or lessons learned while implementing this PR:

- Nothing in particular.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
