### PR TITLE
Implement Top four recently added jobs and saved jobs in Home page

### DIFF
--- a/src/components/TopRecentJobs.jsx
+++ b/src/components/TopRecentJobs.jsx
@@ -29,7 +29,7 @@ const TopRecentJobs = () => {
     <>
       <div className="flex flex-col">
         <div className="flex item-start justify-start">
-          <h4 className="text-bordeaux mb-8">Recently Applied</h4>
+          <h4 className="text-bordeaux font-medium mb-8">Recently Applied</h4>
           <IoIosArrowForward
             onClick={handleNavigateRecent}
             size={25}
@@ -37,7 +37,7 @@ const TopRecentJobs = () => {
           />
         </div>
 
-        <div className="w-full flex border-b border-deepOrange pb-2 mb-4">
+        <div className="w-full flex border-b border-deepOrange pb-2">
           <h5 className="w-1/4 text-deepOrange font-semibold">Company</h5>
           <h5 className="w-1/4 text-deepOrange font-semibold">Role</h5>
           <h5 className="w-1/4 text-deepOrange font-semibold">Date Applied</h5>

--- a/src/components/TopRecentJobs.jsx
+++ b/src/components/TopRecentJobs.jsx
@@ -38,10 +38,10 @@ const TopRecentJobs = () => {
         </div>
 
         <div className="w-full flex border-b border-deepOrange pb-2">
-          <h5 className="w-1/4 text-deepOrange font-semibold">Company</h5>
-          <h5 className="w-1/4 text-deepOrange font-semibold">Role</h5>
-          <h5 className="w-1/4 text-deepOrange font-semibold">Date Applied</h5>
-          <h5 className="w-1/4 text-deepOrange font-semibold">Status</h5>
+          <h6 className="w-1/4 text-deepOrange font-semibold">Company</h6>
+          <h6 className="w-1/4 text-deepOrange font-semibold">Role</h6>
+          <h6 className="w-1/4 text-deepOrange font-semibold">Date Applied</h6>
+          <h6 className="w-1/4 text-deepOrange font-semibold">Status</h6>
         </div>
       </div>
       {recentSavedJobs.map((job, index) => (

--- a/src/components/TopRecentJobs.jsx
+++ b/src/components/TopRecentJobs.jsx
@@ -1,0 +1,69 @@
+import PropTypes from "prop-types";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { IoIosArrowForward } from "react-icons/io";
+
+const TopRecentJobs = () => {
+  const [recentSavedJobs, setRecentSavedJobs] = useState([]);
+  const navigate = useNavigate();
+
+  const handleNavigateRecent = () => {
+    navigate("/jobtracking");
+  };
+
+  useEffect(() => {
+    const data = JSON.parse(localStorage.getItem("applications")) || [];
+
+    // Sort jobs by dateApplied (newest first)
+    const sorted = [...data].sort(
+      (a, b) => new Date(b.date) - new Date(a.date),
+    );
+
+    // Get top 4 most recent
+    const topFour = sorted.slice(0, 4);
+
+    setRecentSavedJobs(topFour);
+  }, []);
+  return (
+    <>
+      <div className="flex flex-col">
+        <div className="flex item-start justify-start">
+          <h4 className="text-bordeaux mb-8">Recently Applied</h4>
+          <IoIosArrowForward
+            onClick={handleNavigateRecent}
+            size={25}
+            className="text-bordeaux text-center mt-1 cursor-pointer"
+          />
+        </div>
+
+        <div className="w-full flex border-b border-deepOrange pb-2 mb-4">
+          <h5 className="w-1/4 text-deepOrange font-semibold">Company</h5>
+          <h5 className="w-1/4 text-deepOrange font-semibold">Role</h5>
+          <h5 className="w-1/4 text-deepOrange font-semibold">Date Applied</h5>
+          <h5 className="w-1/4 text-deepOrange font-semibold">Status</h5>
+        </div>
+      </div>
+      {recentSavedJobs.map((job, index) => (
+        <div key={index} className="flex flex-col">
+          <div className="flex items-center w-full border-b border-divderLines pt-4 pb-2">
+            <p className="w-1/4 truncate text-richMahogany font-semibold">
+              {job.companyName}
+            </p>
+            <p className="w-1/4 font-inter truncate">{job.role}</p>
+            <p className="w-1/4 font-inter truncate">{job.date}</p>
+            <p className="w-1/4 font-inter truncate">{job.status}</p>
+          </div>
+        </div>
+      ))}
+    </>
+  );
+};
+
+TopRecentJobs.propTypes = {
+  company: PropTypes.string,
+  role: PropTypes.string,
+  link: PropTypes.string,
+};
+
+export default TopRecentJobs;

--- a/src/components/TopSavedJobs.jsx
+++ b/src/components/TopSavedJobs.jsx
@@ -31,9 +31,9 @@ const TopSavedJobs = () => {
       </div>
 
       <div className="w-full flex border-b border-deepOrange font-semibold pb-2">
-        <h5 className="w-1/3 text-deepOrange font-semibold">Company</h5>
-        <h5 className="w-1/3 text-deepOrange font-semibold">Role</h5>
-        <h5 className="w-1/3 text-deepOrange font-semibold">Job Link</h5>
+        <h6 className="w-1/3 text-deepOrange font-semibold">Company</h6>
+        <h6 className="w-1/3 text-deepOrange font-semibold">Role</h6>
+        <h6 className="w-1/3 text-deepOrange font-semibold">Job Link</h6>
       </div>
       {topFourSavedJobs.map((job) => (
         <div

--- a/src/components/TopSavedJobs.jsx
+++ b/src/components/TopSavedJobs.jsx
@@ -22,7 +22,7 @@ const TopSavedJobs = () => {
   return (
     <div className="flex flex-col">
       <div className="flex item-start justify-start">
-        <h4 className="text-bordeaux mb-8">Saved Jobs</h4>
+        <h4 className="text-bordeaux font-medium mb-8">Saved Jobs</h4>
         <IoIosArrowForward
           onClick={handleNavigateSaved}
           size={25}
@@ -30,23 +30,23 @@ const TopSavedJobs = () => {
         />
       </div>
 
-      <div className="w-full flex border-b border-deepOrange font-semibold pb-2 mb-4">
+      <div className="w-full flex border-b border-deepOrange font-semibold pb-2">
         <h5 className="w-1/3 text-deepOrange font-semibold">Company</h5>
         <h5 className="w-1/3 text-deepOrange font-semibold">Role</h5>
-        <h5 className="w-1/3 text-deepOrange font-semibold">Link</h5>
+        <h5 className="w-1/3 text-deepOrange font-semibold">Job Link</h5>
       </div>
       {topFourSavedJobs.map((job) => (
         <div
           key={job.id}
           className="w-full flex gap-2 border-b border-gray-300 py-2"
         >
-          <p className="w-1/3 truncate">{job.companyName}</p>
+          <p className="w-1/3 truncate  text-richMahogany font-semibold">{job.companyName}</p>
           <p className="w-1/3 truncate">{job.role}</p>
           <a
             href={job.link}
             target="_blank"
             rel="noopener noreferrer"
-            className="w-1/3 truncate text-blue-600"
+            className="w-1/3 truncate hover:text-gray-600"
           >
             {job.link}
           </a>

--- a/src/components/TopSavedJobs.jsx
+++ b/src/components/TopSavedJobs.jsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { IoIosArrowForward } from "react-icons/io";
+
+const TopSavedJobs = () => {
+  const [topFourSavedJobs, setTopFourSavedJobs] = useState([]);
+  const navigate = useNavigate();
+
+  const handleNavigateSaved = () => {
+    navigate("/jobtracking");
+  };
+
+  useEffect(() => {
+    const savedData = JSON.parse(localStorage.getItem("savedJobs")) || [];
+
+    // Get last 4 jobs (most recent), then reverse to show newest first
+    const lastFour = savedData.slice(-4).reverse();
+
+    setTopFourSavedJobs(lastFour);
+  }, []);
+
+  return (
+    <div className="flex flex-col">
+      <div className="flex item-start justify-start">
+        <h4 className="text-bordeaux mb-8">Saved Jobs</h4>
+        <IoIosArrowForward
+          onClick={handleNavigateSaved}
+          size={25}
+          className="text-bordeaux text-center mt-1 cursor-pointer"
+        />
+      </div>
+
+      <div className="w-full flex border-b border-deepOrange font-semibold pb-2 mb-4">
+        <h5 className="w-1/3 text-deepOrange font-semibold">Company</h5>
+        <h5 className="w-1/3 text-deepOrange font-semibold">Role</h5>
+        <h5 className="w-1/3 text-deepOrange font-semibold">Link</h5>
+      </div>
+      {topFourSavedJobs.map((job) => (
+        <div
+          key={job.id}
+          className="w-full flex gap-2 border-b border-gray-300 py-2"
+        >
+          <p className="w-1/3 truncate">{job.companyName}</p>
+          <p className="w-1/3 truncate">{job.role}</p>
+          <a
+            href={job.link}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="w-1/3 truncate text-blue-600"
+          >
+            {job.link}
+          </a>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default TopSavedJobs;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -11,7 +11,7 @@ const Home = () => {
       <main className="flex flex-row gap-8 items-start">
         {/* Jobs Dashboard */}
 
-        <div className="w-3/5 rounded-[25px] bg-[#FBF9F3] shadow-md p-8">
+        <div className="w-3/5 rounded-[25px] bg-[#FBF9F3] shadow-md p-10">
           {/* Recent Applications Section */}
           <div className="flex flex-col">
             <TopRecentJobs />

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,6 +1,6 @@
-import JobApplication from "../components/JobApplication";
-import SavedJob from "../components/SavedJob";
+import TopSavedJobs from "../components/TopSavedJobs";
 import Navbar from "../components/Navbar";
+import TopRecentJobs from "../components/TopRecentJobs";
 import MotivationBuddy from "../components/MotivationBuddy";
 
 const Home = () => {
@@ -10,47 +10,20 @@ const Home = () => {
 
       <main className="flex flex-row gap-8 items-start">
         {/* Jobs Dashboard */}
-        <div className="w-3/5 rounded-3xl bg-linear-to-r from-gray-50 to-white shadow-md p-8">
+
+        <div className="w-3/5 rounded-[25px] bg-[#FBF9F3] shadow-md p-8">
           {/* Recent Applications Section */}
           <div className="flex flex-col">
-            <h2 className="font-lora font-medium text-2xl mb-8">
-              Recently Applied
-            </h2>
-
-            <div className="w-full flex border-b-2 border-gray-300 pb-2 mb-4">
-              <p className="w-1/4 font-lora font-semibold text-lg">Company</p>
-              <p className="w-1/4 font-lora font-semibold text-lg">Role</p>
-              <p className="w-1/4 font-lora font-semibold text-lg">
-                Date Applied
-              </p>
-              <p className="w-1/4 font-lora font-semibold text-lg">Status</p>
-            </div>
-
-            <JobApplication />
-            <JobApplication />
-            <JobApplication />
-            <JobApplication />
+            <TopRecentJobs />
           </div>
-
           {/* Saved Jobs Section */}
           <div className="flex flex-col mt-8">
-            <h2 className="font-lora font-medium text-2xl mb-8">Saved Jobs</h2>
-
-            <div className="w-full flex border-b-2 border-gray-300 pb-2 mb-4">
-              <p className="w-1/3 font-lora font-semibold text-lg">Company</p>
-              <p className="w-1/3 font-lora font-semibold text-lg">Role</p>
-              <p className="w-1/3 font-lora font-semibold text-lg">Link</p>
-            </div>
-
-            <SavedJob />
-            <SavedJob />
-            <SavedJob />
-            <SavedJob />
+            <TopSavedJobs />
           </div>
         </div>
 
         {/* Motivation Buddy Component */}
-         <MotivationBuddy />
+        <MotivationBuddy />
       </main>
     </div>
   );

--- a/src/pages/JobTracking.jsx
+++ b/src/pages/JobTracking.jsx
@@ -178,7 +178,9 @@ const JobTracking = () => {
                 <h6 className="w-1/6 text-deepOrange font-semibold">
                   Job Type
                 </h6>
-                <h6 className="w-1/6 text-deepOrange font-semibold">Date Applied</h6>
+                <h6 className="w-1/6 text-deepOrange font-semibold">
+                  Date Applied
+                </h6>
                 <h6 className="w-1/6 text-deepOrange font-semibold">Status</h6>
                 <div className="w-20" /> {/* placeholder for icons column */}
               </div>
@@ -236,7 +238,9 @@ const JobTracking = () => {
               <div className="w-full flex border-b border-deepOrange pb-2">
                 <h6 className="w-1/3 text-deepOrange font-semibold">Company</h6>
                 <h6 className="w-1/3 text-deepOrange font-semibold">Role</h6>
-                <h6 className="w-1/3 text-deepOrange font-semibold">Job Link</h6>
+                <h6 className="w-1/3 text-deepOrange font-semibold">
+                  Job Link
+                </h6>
                 <div className="w-24" /> {/* placeholder for icon column */}
               </div>
 


### PR DESCRIPTION
# Pull Request
Populate dashboard to retrieve top 4 recently applied applications and top 4 recently saved jobs
## Story / Issue Link

Link to the related story card or issue:  
[Miro Task-7](https://miro.com/app/board/uXjVJ6oI1BA=/?openSyncedCardPanel=uXjVJr4zDN8%3D:51cf55ef-6e88-4f50-afda-5752301c1d8b::details)

## Description of Work Done

Show the 4 newest jobs (sorted by date).
Show the top 4 saved jobs.
## Testing Instructions

Steps to test this PR:

- Navigate to https://deploy-preview-27--strawberry-swirl.netlify.app/

- When you add a job using the “Add” button in the Recent Applications section of the Job Tracking page, the top 4 most recent jobs are shown in the Recent Jobs section on the Home page.

- When you add a job using the “Add” button in the Saved Jobs section of the Job Tracking page, the 4 most recently saved jobs are shown in the Saved Jobs section on the Home page.

- When you click the arrow icon in the Recent Jobs or Saved Jobs sections on the Home page, it navigates you to the Job Tracking page.

## Gotchas / Lessons Learned

Any tricky parts or lessons learned while implementing this PR:

I learned that the React Router` useNavigate` function helps me move the user to another page in my app with one simple function call.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
