### PR TITLE
remove total num of apps from job stats

### DIFF
--- a/src/components/JobStats.jsx
+++ b/src/components/JobStats.jsx
@@ -23,42 +23,61 @@ const Statuses = () => {
     JSON.parse(localStorage.getItem("savedJobs")) || []
   ).length;
 
+  const totalNumOfApps = (
+    JSON.parse(localStorage.getItem("applications")) || []
+  ).length;
+
   return (
-    <div className="rounded-3xl bg-white shadow-md px-8 py-10">
-      <div className="flex flex-col gap-4">
-        <div className="w-full flex">
-          <h6 className="w-1/3 text-bordeaux font-medium">
-            {totalNumOfSavedJobs}
+    <div className="flex flex-col gap-6">
+      <div className="rounded-3xl bg-white shadow-md px-8 py-10">
+        <div className="flex flex-col gap-4">
+          <h6 className="text-deepOrange font-semibold text-center border-b-2 border-deepOrange pb-2">
+            Application Status
           </h6>
-          <h6 className="w-2/3 text-bordeaux font-medium">Saved</h6>
-        </div>
 
-        <div className="w-full flex">
-          <h6 className="w-1/3 text-bordeaux font-medium">
-            {getStatusAmt("Applied")}
-          </h6>
-          <h6 className="w-2/3 text-bordeaux font-medium">Applied</h6>
-        </div>
+          <div className="w-full flex">
+            <h6 className="w-1/3 text-bordeaux font-medium">
+              {totalNumOfSavedJobs}
+            </h6>
+            <h6 className="w-2/3 text-bordeaux font-medium">Saved</h6>
+          </div>
 
-        <div className="w-full flex">
-          <h6 className="w-1/3 text-bordeaux font-medium">
-            {getStatusAmt("Interviewing")}
-          </h6>
-          <h6 className="w-2/3 text-bordeaux font-medium">Interviewing</h6>
-        </div>
+          <div className="w-full flex">
+            <h6 className="w-1/3 text-bordeaux font-medium">
+              {getStatusAmt("Applied")}
+            </h6>
+            <h6 className="w-2/3 text-bordeaux font-medium">Applied</h6>
+          </div>
 
-        <div className="w-full flex">
-          <h6 className="w-1/3 text-bordeaux font-medium">
-            {getStatusAmt("Rejected")}
-          </h6>
-          <h6 className="w-2/3 text-bordeaux font-medium">Rejected</h6>
-        </div>
+          <div className="w-full flex">
+            <h6 className="w-1/3 text-bordeaux font-medium">
+              {getStatusAmt("Interviewing")}
+            </h6>
+            <h6 className="w-2/3 text-bordeaux font-medium">Interviewing</h6>
+          </div>
 
+          <div className="w-full flex">
+            <h6 className="w-1/3 text-bordeaux font-medium">
+              {getStatusAmt("Rejected")}
+            </h6>
+            <h6 className="w-2/3 text-bordeaux font-medium">Rejected</h6>
+          </div>
+
+          <div className="w-full flex">
+            <h6 className="w-1/3 text-bordeaux font-medium">
+              {getStatusAmt("Offers")}
+            </h6>
+            <h6 className="w-2/3 text-bordeaux font-medium">Offers</h6>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-3xl bg-white shadow-md px-8 py-6">
         <div className="w-full flex">
-          <h6 className="w-1/3 text-bordeaux font-medium">
-            {getStatusAmt("Offers")}
+          <h6 className="w-1/3 text-deepOrange font-semibold">
+            {totalNumOfApps}
           </h6>
-          <h6 className="w-2/3 text-bordeaux font-medium">Offers</h6>
+          <h6 className="w-2/3 text-deepOrange font-semibold">Total Apps</h6>
         </div>
       </div>
     </div>

--- a/src/components/JobStats.jsx
+++ b/src/components/JobStats.jsx
@@ -23,45 +23,43 @@ const Statuses = () => {
     JSON.parse(localStorage.getItem("savedJobs")) || []
   ).length;
 
-  const totalNumOfApps =
-    (JSON.parse(localStorage.getItem("applications")) || []).length +
-    totalNumOfSavedJobs;
-
   return (
     <div className="rounded-3xl bg-white shadow-md px-8 py-10">
-      <div className="flex flex-col gap-4 pb-2">
+      <div className="flex flex-col gap-4">
         <div className="w-full flex">
-          <h6 className="w-1/3 text-bordeaux">{totalNumOfSavedJobs}</h6>
-          <h6 className="w-2/3 text-bordeaux">Saved</h6>
+          <h6 className="w-1/3 text-bordeaux font-medium">
+            {totalNumOfSavedJobs}
+          </h6>
+          <h6 className="w-2/3 text-bordeaux font-medium">Saved</h6>
         </div>
 
         <div className="w-full flex">
-          <h6 className="w-1/3 text-bordeaux">{getStatusAmt("Applied")}</h6>
-          <h6 className="w-2/3 text-bordeaux">Applied</h6>
+          <h6 className="w-1/3 text-bordeaux font-medium">
+            {getStatusAmt("Applied")}
+          </h6>
+          <h6 className="w-2/3 text-bordeaux font-medium">Applied</h6>
         </div>
 
         <div className="w-full flex">
-          <h6 className="w-1/3 text-bordeaux">
+          <h6 className="w-1/3 text-bordeaux font-medium">
             {getStatusAmt("Interviewing")}
           </h6>
-          <h6 className="w-2/3 text-bordeaux">Interviewing</h6>
+          <h6 className="w-2/3 text-bordeaux font-medium">Interviewing</h6>
         </div>
 
         <div className="w-full flex">
-          <h6 className="w-1/3 text-bordeaux">{getStatusAmt("Rejected")}</h6>
-          <h6 className="w-2/3 text-bordeaux">Rejected</h6>
+          <h6 className="w-1/3 text-bordeaux font-medium">
+            {getStatusAmt("Rejected")}
+          </h6>
+          <h6 className="w-2/3 text-bordeaux font-medium">Rejected</h6>
         </div>
 
         <div className="w-full flex">
-          <h6 className="w-1/3 text-bordeaux">{getStatusAmt("Offers")}</h6>
-          <h6 className="w-2/3 text-bordeaux">Offers</h6>
+          <h6 className="w-1/3 text-bordeaux font-medium">
+            {getStatusAmt("Offers")}
+          </h6>
+          <h6 className="w-2/3 text-bordeaux font-medium">Offers</h6>
         </div>
-      </div>
-      <div className="w-full flex border-t border-deepOrange pt-2">
-        <h6 className="w-1/3 text-deepOrange font-semibold">
-          {totalNumOfApps}
-        </h6>
-        <h6 className="w-2/3 text-deepOrange font-semibold">Total No.</h6>
       </div>
     </div>
   );

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -50,7 +50,7 @@ const Home = () => {
         </div>
 
         {/* Motivation Buddy Component */}
-         <MotivationBuddy />
+        <MotivationBuddy />
       </main>
     </div>
   );

--- a/src/pages/JobTracking.jsx
+++ b/src/pages/JobTracking.jsx
@@ -127,6 +127,10 @@ const JobTracking = () => {
     setNumSavedJobs((prev) => prev + 4);
   };
 
+  const totalNumOfApps = (
+    JSON.parse(localStorage.getItem("applications")) || []
+  ).length;
+
   return (
     <div className="bg-backgroundColor min-h-screen px-30 py-8">
       <Navbar />
@@ -211,6 +215,15 @@ const JobTracking = () => {
                     onDelete={handleDeleteJobApp}
                   />
                 ))}
+
+              <div className="flex items-end gap-2 mt-2">
+                <p className="text-[15px] text-richMahogany font-medium">
+                  COUNT
+                </p>
+                <h6 className="text-richMahogany font-medium">
+                  {totalNumOfApps}
+                </h6>
+              </div>
 
               {numJobApps < jobApps.length && (
                 <button

--- a/src/pages/JobTracking.jsx
+++ b/src/pages/JobTracking.jsx
@@ -178,7 +178,9 @@ const JobTracking = () => {
                 <h6 className="w-1/6 text-deepOrange font-semibold">
                   Job Type
                 </h6>
-                <h6 className="w-1/6 text-deepOrange font-semibold">Date Applied</h6>
+                <h6 className="w-1/6 text-deepOrange font-semibold">
+                  Date Applied
+                </h6>
                 <h6 className="w-1/6 text-deepOrange font-semibold">Status</h6>
                 <div className="w-20" /> {/* placeholder for icons column */}
               </div>
@@ -236,7 +238,9 @@ const JobTracking = () => {
               <div className="w-full flex border-b border-deepOrange pb-2">
                 <h6 className="w-1/3 text-deepOrange font-semibold">Company</h6>
                 <h6 className="w-1/3 text-deepOrange font-semibold">Role</h6>
-                <h6 className="w-1/3 text-deepOrange font-semibold">Job Link</h6>
+                <h6 className="w-1/3 text-deepOrange font-semibold">
+                  Job Link
+                </h6>
                 <div className="w-24" /> {/* placeholder for icon column */}
               </div>
 

--- a/src/pages/JobTracking.jsx
+++ b/src/pages/JobTracking.jsx
@@ -127,10 +127,6 @@ const JobTracking = () => {
     setNumSavedJobs((prev) => prev + 4);
   };
 
-  const totalNumOfApps = (
-    JSON.parse(localStorage.getItem("applications")) || []
-  ).length;
-
   return (
     <div className="bg-backgroundColor min-h-screen px-30 py-8">
       <Navbar />
@@ -215,15 +211,6 @@ const JobTracking = () => {
                     onDelete={handleDeleteJobApp}
                   />
                 ))}
-
-              <div className="flex items-end gap-2 mt-2">
-                <p className="text-[15px] text-richMahogany font-medium">
-                  COUNT
-                </p>
-                <h6 className="text-richMahogany font-medium">
-                  {totalNumOfApps}
-                </h6>
-              </div>
 
               {numJobApps < jobApps.length && (
                 <button


### PR DESCRIPTION
# Pull Request

## Description of Work Done

Describe the work you completed in this PR.  
Redesigned indication for total number of applications to be more clear. Based on:
<img width="2012" height="1118" alt="image" src="https://github.com/user-attachments/assets/f164a8ed-9d47-495f-a667-09a766044756" />


## Testing Instructions

Steps to test this PR:

1.  Navigate to https://deploy-preview-28--strawberry-swirl.netlify.app/jobtracking
2.  You should see "COUNT" on the bottom of the Application section (and not the Saved Jobs section)
3.  COUNT tells you how many job applications you have -- covering all of the statuses
4. You can test it by adding and removing job apps (and making sure adding saved jobs will have no effect to the count)

## Gotchas / Lessons Learned

Any tricky parts or lessons learned while implementing this PR:

- None

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation if needed
- [x] My changes generate no new warnings
